### PR TITLE
Restrict permissions of scrape job

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -13,6 +13,8 @@ name: Run scraper
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In fact, the scrape job doesn't need any permissions at all.