### PR TITLE
Bump release-downloader

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download latest release
-      uses: robinraju/release-downloader@v1.5
+      uses: robinraju/release-downloader@v1.6
       with:
         repository: disksing/twiyou
         latest: true


### PR DESCRIPTION
Bump release-downloader to fix the warning:
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```